### PR TITLE
Simplify and fix caching strategy

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+const _latLng = require('./node_modules/node-hgt/src/latlng');
+const tileKey = require('./node_modules/node-hgt/src/tile-key');
+const Hgt = require('./node_modules/node-hgt/src/hgt');
+
+function loadTile(tileDir, latLng) {
+    const ll = {
+        lat: Math.floor(latLng.lat),
+        lng: Math.floor(latLng.lng)
+    }
+    const key = tileKey(ll);
+    const tilePath = path.join(tileDir, key + '.hgt');
+
+    const tileExists = fs.existsSync(tilePath);
+    if (!tileExists) return [{message: 'Tile does not exist: ' + tilePath}]
+
+    try {
+        const tile = new Hgt(tilePath, ll);
+        return [undefined, tile];
+    } catch(e) {
+        return [{message: 'Unable to load tile "' + tilePath + '": ' + e, stack: e.stack}];
+    }
+}
+
+function TileSet(tileDir) {
+    this._tileDir = tileDir;
+}
+
+TileSet.prototype.destroy = function() {};
+
+TileSet.prototype.getElevation = function(latLng, cb) {
+    const ll = _latLng(latLng);
+    const [error, tile] = loadTile(this._tileDir, ll);
+
+    if (error) return cb(error);
+    const elevation = tile.getElevation(ll)
+    if (isNaN(elevation)) return cb(elevation);
+    cb(undefined, elevation);
+};
+
+module.exports = TileSet;
+

--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -1,10 +1,25 @@
 const fs = require('fs');
 const path = require('path');
+const LRU = require('lru-cache');
 const _latLng = require('./node_modules/node-hgt/src/latlng');
 const tileKey = require('./node_modules/node-hgt/src/tile-key');
 const Hgt = require('./node_modules/node-hgt/src/hgt');
 
-function loadTile(tileDir, latLng) {
+function TileSet(tileDir) {
+    this._tileDir = tileDir;
+    this._cache = new LRU({
+        // 500mb
+        max: 500000000,
+        // 12 hours
+        maxAge: 1000 * 60 * 60 * 12,
+        length: n => n._buffer.length,
+        updateAgeOnGet: true,
+    })
+}
+
+TileSet.prototype.destroy = function() {};
+
+TileSet.prototype._loadTile = function(tileDir, latLng) {
     const ll = {
         lat: Math.floor(latLng.lat),
         lng: Math.floor(latLng.lng)
@@ -12,26 +27,24 @@ function loadTile(tileDir, latLng) {
     const key = tileKey(ll);
     const tilePath = path.join(tileDir, key + '.hgt');
 
+    const cachedTile = this._cache.get(key);
+    if (cachedTile) return [undefined, cachedTile];
+
     const tileExists = fs.existsSync(tilePath);
     if (!tileExists) return [{message: 'Tile does not exist: ' + tilePath}]
 
     try {
         const tile = new Hgt(tilePath, ll);
+        this._cache.set(key, tile);
         return [undefined, tile];
     } catch(e) {
         return [{message: 'Unable to load tile "' + tilePath + '": ' + e, stack: e.stack}];
     }
 }
 
-function TileSet(tileDir) {
-    this._tileDir = tileDir;
-}
-
-TileSet.prototype.destroy = function() {};
-
 TileSet.prototype.getElevation = function(latLng, cb) {
     const ll = _latLng(latLng);
-    const [error, tile] = loadTile(this._tileDir, ll);
+    const [error, tile] = this._loadTile(this._tileDir, ll);
 
     if (error) return cb(error);
     const elevation = tile.getElevation(ll)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const {addElevation} = require('geojson-elevation');
-const {TileSet, ImagicoElevationDownloader} = require('node-hgt');
+const GaiaTileSet = require('./GaiaTileSet');
 const express = require('express');
 const bodyParser = require('body-parser');
 const app = express();
@@ -7,14 +7,7 @@ const port = process.env.PORT || 5001;
 
 const tileDirectory = process.env.TILE_DIRECTORY || './data';
 
-let tileDownloader;
-if (!process.env.TILE_DOWNLOADER && process.env.TILE_DOWNLOADER === 'imagico') {
-    tileDownloader = new ImagicoElevationDownloader(tileDirectory);
-} else if (process.env.TILE_DOWNLOADER === 'none') {
-    tileDownloader = undefined;
-}
-
-const tiles = new TileSet(tileDirectory, {downloader:tileDownloader});
+const tiles = new GaiaTileSet(tileDirectory);
 const noData = process.env.NO_DATA ? parseInt(process.env.NO_DATA) : undefined;
 
 app.use(bodyParser.json({limit: process.env.MAX_POST_SIZE || '500kb'}));


### PR DESCRIPTION
`node-hgt` uses an [improperly configured](https://github.com/perliedman/node-hgt/blob/master/src/tile-set.js#L18) LRU cache with a default value of `1000` with no `length` checker. In practice this means that 1000 tiles will be cached. If each tile is about 24mb, that will be over 20gb of cached tiles.

This PR implements our own tile getter that properly configures the tile cache to only cache 500mb of data. It also improves async handling by removing the [`loadQueue`](https://github.com/perliedman/node-hgt/blob/master/src/tile-set.js#L67) that was responsible for throwing errors in production by invoking the callback more than once.

