### PR TITLE
Create a new elevation provider

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -42,14 +42,14 @@ TileSet.prototype._loadTile = function(tileDir, latLng) {
     }
 }
 
-TileSet.prototype.getElevation = function(latLng, cb) {
+TileSet.prototype.getElevation = function(latLng) {
     const ll = _latLng(latLng);
     const [error, tile] = this._loadTile(this._tileDir, ll);
 
-    if (error) return cb(error);
+    if (error) return [error];
     const elevation = tile.getElevation(ll)
-    if (isNaN(elevation)) return cb(elevation);
-    cb(undefined, elevation);
+    if (isNaN(elevation)) return [elevation];
+    return [undefined, elevation];
 };
 
 module.exports = TileSet;

--- a/addElevation.js
+++ b/addElevation.js
@@ -1,15 +1,12 @@
 const {coordEach} = require('@turf/meta');
 
 module.exports = (geojson, elevationProvider) => {
-    const errors = []
+    let error = undefined;
     coordEach(geojson, coords => {
-        const [error, elevation] = elevationProvider.getElevation([coords[1], coords[0]]);
-        if (error) {
-            errors.push(error)
-            return;
-        };
+        const [elevationError, elevation] = elevationProvider.getElevation([coords[1], coords[0]]);
+        error = elevationError
         coords[2] = elevation;
     });
-    if (errors.length) return [errors[0]];
-    return [undefined, geojson];
+
+    return [error, geojson];
 }

--- a/addElevation.js
+++ b/addElevation.js
@@ -1,0 +1,15 @@
+const {coordEach} = require('@turf/meta');
+
+module.exports = (geojson, elevationProvider) => {
+    const errors = []
+    coordEach(geojson, coords => {
+        const [error, elevation] = elevationProvider.getElevation([coords[1], coords[0]]);
+        if (error) {
+            errors.push(error)
+            return;
+        };
+        coords[2] = elevation;
+    });
+    if (errors.length) return [errors[0]];
+    return [undefined, geojson];
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {addElevation} = require('geojson-elevation');
+const addElevation = require('./addElevation');
 const GaiaTileSet = require('./GaiaTileSet');
 const express = require('express');
 const bodyParser = require('body-parser');
@@ -8,7 +8,6 @@ const port = process.env.PORT || 5001;
 const tileDirectory = process.env.TILE_DIRECTORY || './data';
 
 const tiles = new GaiaTileSet(tileDirectory);
-const noData = process.env.NO_DATA ? parseInt(process.env.NO_DATA) : undefined;
 
 app.use(bodyParser.json({limit: process.env.MAX_POST_SIZE || '500kb'}));
 
@@ -35,13 +34,13 @@ app.post('/geojson', (req, res) => {
         return;
     }
 
-    addElevation(geojson, tiles, (err) => {
-        if (err) {
-            console.log(err);
-            return res.status(500).json(err);
-        }
-        res.json(geojson);
-    }, noData);
+    const [error, output] = addElevation(geojson, tiles);
+    if (error) {
+        console.log(error);
+        return res.status(500).json(error);
+    }
+
+    res.json(output);
 });
 
 app.get('/status', (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -315,15 +315,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "geojson-elevation": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/geojson-elevation/-/geojson-elevation-1.1.2.tgz",
-      "integrity": "sha512-8gqkTtyHHKQKvsPy27t+GnSDXgOldDhT1NB0sqA/ydOl1sQceBg/3KfjamiSYMKnJMO3bCUe8gbSrNl477Gq3A==",
-      "requires": {
-        "@turf/meta": "^6.0.2",
-        "node-hgt": "^1.2.2"
-      }
-    },
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -428,12 +419,11 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "yallist": "^3.0.2"
       }
     },
     "media-typer": {
@@ -489,6 +479,22 @@
         "promise": "^8.0.0",
         "request": "^2.88.0",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "oauth-sign": {
@@ -760,9 +766,9 @@
       }
     },
     "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "author": "Per Liedman <per@liedman.net>",
   "license": "ISC",
   "dependencies": {
+    "@turf/meta": "^6.0.2",
     "body-parser": "^1.12.2",
     "express": "^4.12.3",
-    "geojson-elevation": "^1.1.0",
+    "lru-cache": "^5.1.1",
     "node-hgt": "^1.1.0"
   }
 }


### PR DESCRIPTION
While looking through the logs of the new elevation service I noticed the following error:

````
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
````

This means that the response object was called more than once for a given request. After digging around a bit I discovered that `geojson-elevation` [invokes the callback for _every_ error](https://github.com/perliedman/geojson-elevation/blob/master/index.js#L17) which will result in us attempting to send multiple responses. 

To fix this I created our own version that is completely synchronous and removes a lot of unnecessary async code. 