### PR TITLE
Don't throw errors; configure NO_DATA

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -5,7 +5,7 @@ const _latLng = require('./node_modules/node-hgt/src/latlng');
 const tileKey = require('./node_modules/node-hgt/src/tile-key');
 const Hgt = require('./node_modules/node-hgt/src/hgt');
 
-function TileSet(tileDir) {
+function TileSet(tileDir, NO_DATA = 0) {
     this._tileDir = tileDir;
     this._cache = new LRU({
         // 500mb
@@ -14,7 +14,8 @@ function TileSet(tileDir) {
         maxAge: 1000 * 60 * 60 * 12,
         length: n => n._buffer.length,
         updateAgeOnGet: true,
-    })
+    });
+    this._NO_DATA = NO_DATA;
 }
 
 TileSet.prototype.destroy = function() {};
@@ -46,10 +47,10 @@ TileSet.prototype.getElevation = function(latLng) {
     const ll = _latLng(latLng);
     const [error, tile] = this._loadTile(this._tileDir, ll);
 
-    if (error) return [error];
+    if (error) return [error, this._NO_DATA];
     const elevation = tile.getElevation(ll)
-    if (isNaN(elevation)) return [elevation];
-    return [undefined, elevation || 0];
+    if (isNaN(elevation)) return [elevation, this._NO_DATA];
+    return [undefined, elevation || this._NO_DATA];
 };
 
 module.exports = TileSet;

--- a/addElevation.js
+++ b/addElevation.js
@@ -1,12 +1,10 @@
 const {coordEach} = require('@turf/meta');
 
 module.exports = (geojson, elevationProvider) => {
-    let error = undefined;
     coordEach(geojson, coords => {
-        const [elevationError, elevation] = elevationProvider.getElevation([coords[1], coords[0]]);
-        error = elevationError
+        const [, elevation] = elevationProvider.getElevation([coords[1], coords[0]]);
         coords[2] = elevation;
     });
 
-    return [error, geojson];
+    return [undefined, geojson];
 }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ const app = express();
 const port = process.env.PORT || 5001;
 
 const tileDirectory = process.env.TILE_DIRECTORY || './data';
+const NO_DATA = process.env.NO_DATA || 0;
 
-const tiles = new GaiaTileSet(tileDirectory);
+const tiles = new GaiaTileSet(tileDirectory, NO_DATA);
 
 app.use(bodyParser.json({limit: process.env.MAX_POST_SIZE || '500kb'}));
 
@@ -34,12 +35,7 @@ app.post('/geojson', (req, res) => {
         return;
     }
 
-    const [error, output] = addElevation(geojson, tiles);
-    if (error) {
-        console.log(error);
-        return res.status(500).json(error);
-    }
-
+    const [, output] = addElevation(geojson, tiles);
     res.json(output);
 });
 


### PR DESCRIPTION
This PR makes the following changes:

- Allows for a `NO_DATA` environment variable to be passed. The default value is `0`.
- Reconfigures the service to never return elevation lookup errors - instead all elevations will be set to the `NO_DATA` value.

