### PR TITLE
Listen on all IPV4 interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ fastify.get('/status', (req, reply) => {
 
 (async () => {
     try {
-        await fastify.listen(port)
+        await fastify.listen(port, '0.0.0.0')
         fastify.log.info(`elevation-server listening on port ${port}`)
     } catch (error) {
         fastify.log.error(error)


### PR DESCRIPTION
When we switched from using Express to Fastify I didn't realize that `listen()` takes an additional parameter that can specify that the server listen on all IPV4 interfaces instead of just 127.0.0.1. This PR adds that parameter.

See "Note" here - https://www.fastify.io/docs/latest/Getting-Started/#your-first-server