### PR TITLE
Ensure a tile exists before caching it

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -44,7 +44,9 @@ GaiaTileSet.prototype._loadTile = function (coord, callback) {
         const tilePath = path.join(this._tileDir, key + '.hgt');
         HGT(tilePath, coord, undefined, (error, tile) => {
             setImmediate(() => {
-                this._cache.set(key, tile);
+                if (!error && tile) {
+                    this._cache.set(key, tile);
+                }
 
                 // Call all of the queued callbacks
                 this._tileLoadingQueue[key].forEach(cb => {


### PR DESCRIPTION
While refactoring the tile loading queue I accidentally made a change that resulted in the cache setting `undefined` values, which resulted in the LRU cache throwing an unhandled error when it attempted to get the length of the (nonexistent) buffer. 