### PR TITLE
Run server under pm2

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 node_modules
 npm-debug.log
+test
+data
+codeship-*
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,10 @@ WORKDIR /usr/src/elevation-service
 
 COPY ./package*.json ./
 
+RUN npm install -g pm2
 RUN npm install
 
 COPY ./. .
 
 EXPOSE 5001
-CMD ["node", "index.js"]
+CMD ["pm2-runtime", "index.js"]


### PR DESCRIPTION
Currently if the server encounters an unhandled error it does not restart. In production we must wait for the container to fail its health checks before a new container is put in its place. This is inefficient and slow, and the load balancer will continue to route requests to the container in the time between the service dying and the health checks failing, resulting in a large number of requests failing with a 500.

This PR wraps the process in `pm2-runtime`, the version of [pm2](https://pm2.keymetrics.io) for use in containers, which will automatically restart the service if it stops.

I tested this by building the image and testing it locally.