### PR TITLE
Ensure all routes accept a HEAD request

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const fastify = require('fastify')({
 
 fastify.register(require('fastify-cors', {
     origin: '*',
-    methods: ['GET', 'OPTIONS', 'POST'],
+    methods: ['GET', 'HEAD', 'OPTIONS', 'POST'],
     allowedHeaders: 'Origin, X-Requested-With, Content-Type, Accept',
 }))
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const fastify = require('fastify')({
     bodyLimit: process.env.MAX_POST_SIZE || 500000,
     connectionTimeout: 10000,
     keepAliveTimeout: 5000,
+    exposeHeadRoutes: true,
 });
 
 fastify.register(require('fastify-cors', {
@@ -35,10 +36,10 @@ fastify.post('/geojson', (req, reply) => {
     tiles.addElevation(geojson, (error, output) => setImmediate(() => {
         if (error) {
             fastify.log.error(error)
-            return reply.code(500).send({'Error': 'Elevation unavailable'});
+            reply.code(500).send({'Error': 'Elevation unavailable'});
+        } else {
+            reply.send(output);
         }
-
-        reply.send(output);
     }));
 });
 


### PR DESCRIPTION
While looking over the logs I noticed that `HEAD` requests were throwing a 404, and realized that fastify does not expose those by default on `GET` routes. 

This PR also makes a small tweak to ensure that a response cannot be used multiple times.