### PR TITLE
Increase timeouts

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const fastify = require('fastify')({
     disableRequestLogging: true,
     // 500kb
     bodyLimit: process.env.MAX_POST_SIZE || 500000,
-    connectionTimeout: 10000,
-    keepAliveTimeout: 5000,
+    connectionTimeout: 30000,
+    keepAliveTimeout: 20000,
     exposeHeadRoutes: true,
 });
 


### PR DESCRIPTION
AWS [suggests](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/application-load-balancers.html#connection-idle-timeout) having a `keepAliveTimeout` greater than that of the application load balancer. I think this discrepancy is resulting in 5xx from the load balancer.