### PR TITLE
Add timing for tile access and long requests

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -41,9 +41,15 @@ GaiaTileSet.prototype._loadTile = function (coord, callback) {
     } else {
         this._tileLoadingQueue[key] = [callback];
 
+        const start = process.hrtime();
         const tilePath = path.join(this._tileDir, key + '.hgt');
         HGT(tilePath, coord, undefined, (error, tile) => {
             setImmediate(() => {
+                const end = process.hrtime(start);
+                if (end[0] > 1) {
+                    console.log(`Loading tile ${key} took ${end[0]}s ${Math.round(end[1] / 1000000)}ms`);
+                }
+
                 if (!error && tile) {
                     this._cache.set(key, tile);
                 }

--- a/index.js
+++ b/index.js
@@ -32,8 +32,13 @@ fastify.post('/geojson', (req, reply) => {
         reply.code(400).send({'Error': 'invalid geojson'});
         return;
     }
-
+    const start = process.hrtime();
     tiles.addElevation(geojson, (error, output) => setImmediate(() => {
+        const end = process.hrtime(start);
+        if (end[0] > 1) {
+            console.log(`Adding elevation took ${end[0]}s ${Math.round(end[1] / 1000000)}ms`);
+            console.log(JSON.stringify(geojson))
+        }
         if (error) {
             fastify.log.error(error)
             reply.code(500).send({'Error': 'Elevation unavailable'});


### PR DESCRIPTION
I've noticed that we periodically have spikes in the max target response time on the service, and I'd like to have some additional logging around the source of those spikes.

This PR will log the tile and associated access time when fetching a tile from "disk" (EFS) takes longer than 1s, as well as when adding elevation to a geometry takes longer than 1s. Ideally this PR will be reverted after gathering data for a day or two.

I tested this by removing the `if` around the logging and testing the service.