### PR TITLE
Fetch tiles from s3

### DIFF
--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -43,18 +43,16 @@ GaiaTileSet.prototype._loadTile = function (coord, callback) {
 
         const tilePath = path.join(this._tileDir, key + '.hgt');
         HGT(tilePath, coord, undefined, (error, tile) => {
-            setImmediate(() => {
-                if (!error && tile) {
-                    this._cache.set(key, tile);
-                }
+            if (!error && tile) {
+                this._cache.set(key, tile);
+            }
 
-                // Call all of the queued callbacks
-                this._tileLoadingQueue[key].forEach(cb => {
-                    if (error) return cb({message: error});
-                    cb(undefined, tile);
-                });
-                delete this._tileLoadingQueue[key];
+            // Call all of the queued callbacks
+            this._tileLoadingQueue[key].forEach(cb => {
+                if (error) return cb({message: error});
+                cb(undefined, tile);
             });
+            delete this._tileLoadingQueue[key];
         });
     }
 };
@@ -83,9 +81,7 @@ GaiaTileSet.prototype.addElevation = function (geojson, callback) {
             elevated++;
 
             if (elevated === coordCount) {
-                setImmediate(() => {
-                    callback(undefined, geojson);
-                });
+                callback(undefined, geojson);
             }
         });
     });

--- a/GaiaTileSet.js
+++ b/GaiaTileSet.js
@@ -66,13 +66,11 @@ GaiaTileSet.prototype._loadTile = function (coord, callback) {
 // Given a coordinate in the format [longitude, latitude], return an elevation
 GaiaTileSet.prototype.getElevation = function (coord, callback) {
     this._loadTile(coord, (error, tile) => {
-        setImmediate(() => {
-            if (error) return callback(error, this._NO_DATA);
+        if (error) return callback(error, this._NO_DATA);
 
-            const elevation = getHGTElevation(tile, coord);
-            if (isNaN(elevation)) return callback(elevation, this._NO_DATA);
-            return callback(undefined, elevation || this._NO_DATA);
-        });
+        const elevation = getHGTElevation(tile, coord);
+        if (isNaN(elevation)) return callback(elevation, this._NO_DATA);
+        return callback(undefined, elevation || this._NO_DATA);
     });
 };
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm run test
 #### Environment
 
 - `PORT`: default `5001`
-- `TILE_DIRECTORY`: default `./data`
-- `TILE_DOWNLOADER`: default `undefined`
+- `TILE_DIRECTORY`: default `./data`. Can also be an S3 prefix
+- `ELEVATION_BUCKET`: S3 bucket that contains elevation data
 - `NO_DATA`: default `undefined`
 - `MAX_POST_SIZE`: default `500kb`

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npm run test
 
 - `PORT`: default `5001`
 - `TILE_DIRECTORY`: default `./data`. Can also be an S3 prefix
-- `ELEVATION_BUCKET`: S3 bucket that contains elevation data
+- `AWS_ELEVATION_BUCKET`: S3 bucket that contains elevation data
+- `AWS_REGION`: Region for `ELEVATION_BUCKET`
 - `NO_DATA`: default `undefined`
 - `MAX_POST_SIZE`: default `500kb`

--- a/hgt/index.js
+++ b/hgt/index.js
@@ -2,12 +2,12 @@ const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3')
 const THREE_ARC_SECOND = 1442401 * 2;
 const ONE_ARC_SECOND = 12967201 * 2;
 
-const s3Client = new S3Client();
+const s3Client = new S3Client({region: process.env.AWS_REGION || 'us-east-1'});
 
 // Adapted from https://github.com/perliedman/node-hgt/blob/master/src/hgt.js
 function HGT(path, swLngLat, options, callback) {
     s3Client.send(new GetObjectCommand({
-        Bucket: process.env.ELEVATION_BUCKET,
+        Bucket: process.env.AWS_ELEVATION_BUCKET,
         Key: path
     })).then(async (dem) => {
         const [resError, resAndSize] = getResolutionAndSize(

--- a/hgt/index.js
+++ b/hgt/index.js
@@ -15,7 +15,7 @@ function HGT(path, swLngLat, options, callback) {
         );
         if (resError) return callback(resError);
 
-        const buffer = await streamToBuffer(dem.Body)
+        const buffer = await streamToBuffer(dem.Body);
         return callback(undefined, {
             buffer,
             resolution: resAndSize.resolution,
@@ -24,8 +24,8 @@ function HGT(path, swLngLat, options, callback) {
             swLngLat,
         });
     }).catch((error) => {
-        console.log(`Error fetching tile ${path}`, error)
-        callback(`Error fetching tile ${path}`)
+        console.log(`Error fetching tile ${path}`, error);
+        callback(`Error fetching tile ${path}`);
     });
 }
 

--- a/hgt/index.js
+++ b/hgt/index.js
@@ -1,39 +1,31 @@
-const fs = require('fs');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3')
 const THREE_ARC_SECOND = 1442401 * 2;
 const ONE_ARC_SECOND = 12967201 * 2;
 
+const s3Client = new S3Client();
+
 // Adapted from https://github.com/perliedman/node-hgt/blob/master/src/hgt.js
 function HGT(path, swLngLat, options, callback) {
-    // Make sure the file exists
-    fs.open(path, 'r', (error, fd) => {
-        setImmediate(() => {
-            if (error) return callback(error);
+    s3Client.send(new GetObjectCommand({
+        Bucket: process.env.ELEVATION_BUCKET,
+        Key: path
+    })).then(async (dem) => {
+        const [resError, resAndSize] = getResolutionAndSize(
+            dem.ContentLength
+        );
+        if (resError) return callback(resError);
 
-            // Determine the type of HGT file based on the size of the file
-            fs.fstat(fd, (error, stats) => {
-                setImmediate(() => {
-                    if (error) return callback(error);
-                    const [resError, resAndSize] = getResolutionAndSize(
-                        stats.size
-                    );
-                    if (resError) return callback(resError);
-
-                    // Stream the file contents to a Buffer
-                    getHGTBuffer(path, (error, buffer) => {
-                        setImmediate(() => {
-                            if (error) return callback(error);
-                            callback(undefined, {
-                                buffer,
-                                resolution: resAndSize.resolution,
-                                size: resAndSize.size,
-                                options,
-                                swLngLat,
-                            });
-                        });
-                    });
-                });
-            });
+        const buffer = await streamToBuffer(dem.Body)
+        return callback(undefined, {
+            buffer,
+            resolution: resAndSize.resolution,
+            size: resAndSize.size,
+            options,
+            swLngLat,
         });
+    }).catch((error) => {
+        console.log(`Error fetching tile ${path}`, error)
+        callback(`Error fetching tile ${path}`)
     });
 }
 
@@ -60,15 +52,13 @@ function getResolutionAndSize(size) {
     }
 }
 
-// Stream an HGT file into a buffer
-function getHGTBuffer(fileDescriptor, callback) {
-    const readStream = fs.createReadStream(fileDescriptor);
-
-    let buffer = [];
-    readStream
-        .on('data', (chunk) => buffer.push(chunk))
-        .on('error', () => callback('Unable to read buffer', null))
-        .on('end', () => callback(null, Buffer.concat(buffer)));
-}
+// Stream an HGT file from S3 into a buffer
+const streamToBuffer = (stream) =>
+    new Promise((resolve, reject) => {
+        const chunks = [];
+        stream.on('data', (chunk) => chunks.push(chunk));
+        stream.on('error', reject);
+        stream.on('end', () => resolve(Buffer.concat(chunks)));
+    });
 
 module.exports = HGT;

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ fastify.post('/geojson', (req, reply) => {
         return;
     }
     const start = process.hrtime();
-    tiles.addElevation(geojson, (error, output) => setImmediate(() => {
+    tiles.addElevation(geojson, (error, output) => () => {
         const end = process.hrtime(start);
         if (end[0] > 1) {
             console.log(`Adding elevation took ${end[0]}s ${Math.round(end[1] / 1000000)}ms`);
@@ -61,7 +61,7 @@ fastify.post('/geojson', (req, reply) => {
         } else {
             reply.send(output);
         }
-    }));
+    });
 });
 
 fastify.get('/status', (req, reply) => {

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ fastify.post('/geojson', (req, reply) => {
         return;
     }
     const start = process.hrtime();
-    tiles.addElevation(geojson, (error, output) => () => {
+    tiles.addElevation(geojson, (error, output) => setImmediate(() => {
         const end = process.hrtime(start);
         if (end[0] > 1) {
             console.log(`Adding elevation took ${end[0]}s ${Math.round(end[1] / 1000000)}ms`);
@@ -61,7 +61,7 @@ fastify.post('/geojson', (req, reply) => {
         } else {
             reply.send(output);
         }
-    });
+    }));
 });
 
 fastify.get('/status', (req, reply) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,862 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@aws-crypto/crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-1.0.0.tgz",
+      "integrity": "sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz",
+      "integrity": "sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-1.1.0.tgz",
+      "integrity": "sha512-VIpuLRDonMAHgomrsm/zKbeXTnxpr4aHDQmS4pF+NcpvBp64l675yjGA9hyUYs/QJwBjUl8WqMjh9tIRgi85Sg==",
+      "requires": {
+        "@aws-crypto/ie11-detection": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.1.0",
+        "@aws-crypto/supports-web-crypto": "^1.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-1.1.0.tgz",
+      "integrity": "sha512-VIhuqbPgXDVr8sZe2yhgQcDRRmzf4CI8fmC1A3bHiRfE6wlz1d8KpeemqbuoEHotz/Dch9yOxlshyQDNjNFeHA==",
+      "requires": {
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz",
+      "integrity": "sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==",
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.13.1.tgz",
+      "integrity": "sha512-iK32oE9hZw3aC6Jgbr8kHGxo1Mq7ayY1dxLB2R59W0YUMB/EEQ2Z0tJaxOsLNfeNBGMvxzQXHxnjP8wUbOGCkA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.13.1.tgz",
+      "integrity": "sha512-vZ292PZUkO7lYba5qz6xcOAwnY9YvjFJM+CEzUsyr7pTBIs/1c9LMZqEMPB9OKKNRmWbB5VwaS2eJQK0KRtr5Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.13.1.tgz",
+      "integrity": "sha512-PJYLDW5Uc78iwHVJmiGMIRIAwohaewOJGsnnwTGQBsOqTHDM0ywwO3rlObkuuLiWaFA/4w1cYdvWaMI7Iwf+qg==",
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.14.0.tgz",
+      "integrity": "sha512-YAlSg60BgYDQzSTusWOH38OYKF8EOj4BFotrWxeFDAvDg40N/n1hYVEe/uOWjPTTQUXj7td4DBPxTr4r3QBY0g==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/client-sts": "3.14.0",
+        "@aws-sdk/config-resolver": "3.14.0",
+        "@aws-sdk/credential-provider-node": "3.14.0",
+        "@aws-sdk/eventstream-serde-browser": "3.13.1",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.13.1",
+        "@aws-sdk/eventstream-serde-node": "3.13.1",
+        "@aws-sdk/fetch-http-handler": "3.13.1",
+        "@aws-sdk/hash-blob-browser": "3.13.1",
+        "@aws-sdk/hash-node": "3.13.1",
+        "@aws-sdk/hash-stream-node": "3.13.1",
+        "@aws-sdk/invalid-dependency": "3.13.1",
+        "@aws-sdk/md5-js": "3.13.1",
+        "@aws-sdk/middleware-apply-body-checksum": "3.13.1",
+        "@aws-sdk/middleware-bucket-endpoint": "3.13.1",
+        "@aws-sdk/middleware-content-length": "3.13.1",
+        "@aws-sdk/middleware-expect-continue": "3.13.1",
+        "@aws-sdk/middleware-host-header": "3.13.1",
+        "@aws-sdk/middleware-location-constraint": "3.13.1",
+        "@aws-sdk/middleware-logger": "3.13.1",
+        "@aws-sdk/middleware-retry": "3.13.1",
+        "@aws-sdk/middleware-sdk-s3": "3.13.1",
+        "@aws-sdk/middleware-serde": "3.13.1",
+        "@aws-sdk/middleware-signing": "3.13.1",
+        "@aws-sdk/middleware-ssec": "3.13.1",
+        "@aws-sdk/middleware-stack": "3.13.1",
+        "@aws-sdk/middleware-user-agent": "3.14.0",
+        "@aws-sdk/node-config-provider": "3.13.1",
+        "@aws-sdk/node-http-handler": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/smithy-client": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/url-parser": "3.13.1",
+        "@aws-sdk/util-base64-browser": "3.13.1",
+        "@aws-sdk/util-base64-node": "3.13.1",
+        "@aws-sdk/util-body-length-browser": "3.13.1",
+        "@aws-sdk/util-body-length-node": "3.13.1",
+        "@aws-sdk/util-user-agent-browser": "3.13.1",
+        "@aws-sdk/util-user-agent-node": "3.13.1",
+        "@aws-sdk/util-utf8-browser": "3.13.1",
+        "@aws-sdk/util-utf8-node": "3.13.1",
+        "@aws-sdk/util-waiter": "3.13.1",
+        "@aws-sdk/xml-builder": "3.14.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.14.0.tgz",
+      "integrity": "sha512-uPg6AvCA5Xp2fzepmG5MDuBqcpeZZGhWmCWIqM+JwmcxU0bw/imHWuHLD4mVFw3yFL7NVfXu89wUyUTa383RZw==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.14.0",
+        "@aws-sdk/fetch-http-handler": "3.13.1",
+        "@aws-sdk/hash-node": "3.13.1",
+        "@aws-sdk/invalid-dependency": "3.13.1",
+        "@aws-sdk/middleware-content-length": "3.13.1",
+        "@aws-sdk/middleware-host-header": "3.13.1",
+        "@aws-sdk/middleware-logger": "3.13.1",
+        "@aws-sdk/middleware-retry": "3.13.1",
+        "@aws-sdk/middleware-serde": "3.13.1",
+        "@aws-sdk/middleware-stack": "3.13.1",
+        "@aws-sdk/middleware-user-agent": "3.14.0",
+        "@aws-sdk/node-config-provider": "3.13.1",
+        "@aws-sdk/node-http-handler": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/smithy-client": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/url-parser": "3.13.1",
+        "@aws-sdk/util-base64-browser": "3.13.1",
+        "@aws-sdk/util-base64-node": "3.13.1",
+        "@aws-sdk/util-body-length-browser": "3.13.1",
+        "@aws-sdk/util-body-length-node": "3.13.1",
+        "@aws-sdk/util-user-agent-browser": "3.13.1",
+        "@aws-sdk/util-user-agent-node": "3.13.1",
+        "@aws-sdk/util-utf8-browser": "3.13.1",
+        "@aws-sdk/util-utf8-node": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.14.0.tgz",
+      "integrity": "sha512-R6z/o8zSe1kYPC/aC3VxYjat3UF1f4BwAShF9JFwi5YUpgD42WzOLuoQ5tjGdvj8cYsq4m9pIOGOPSrEGZZs0Q==",
+      "requires": {
+        "@aws-crypto/sha256-browser": "^1.0.0",
+        "@aws-crypto/sha256-js": "^1.0.0",
+        "@aws-sdk/config-resolver": "3.14.0",
+        "@aws-sdk/credential-provider-node": "3.14.0",
+        "@aws-sdk/fetch-http-handler": "3.13.1",
+        "@aws-sdk/hash-node": "3.13.1",
+        "@aws-sdk/invalid-dependency": "3.13.1",
+        "@aws-sdk/middleware-content-length": "3.13.1",
+        "@aws-sdk/middleware-host-header": "3.13.1",
+        "@aws-sdk/middleware-logger": "3.13.1",
+        "@aws-sdk/middleware-retry": "3.13.1",
+        "@aws-sdk/middleware-sdk-sts": "3.13.1",
+        "@aws-sdk/middleware-serde": "3.13.1",
+        "@aws-sdk/middleware-signing": "3.13.1",
+        "@aws-sdk/middleware-stack": "3.13.1",
+        "@aws-sdk/middleware-user-agent": "3.14.0",
+        "@aws-sdk/node-config-provider": "3.13.1",
+        "@aws-sdk/node-http-handler": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/smithy-client": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/url-parser": "3.13.1",
+        "@aws-sdk/util-base64-browser": "3.13.1",
+        "@aws-sdk/util-base64-node": "3.13.1",
+        "@aws-sdk/util-body-length-browser": "3.13.1",
+        "@aws-sdk/util-body-length-node": "3.13.1",
+        "@aws-sdk/util-user-agent-browser": "3.13.1",
+        "@aws-sdk/util-user-agent-node": "3.13.1",
+        "@aws-sdk/util-utf8-browser": "3.13.1",
+        "@aws-sdk/util-utf8-node": "3.13.1",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.14.0.tgz",
+      "integrity": "sha512-ZuwxcQro817xq6qE9HJaWRm+cJGCXHU2ZVrSNEmU+E79gJVw2Bo+99Pk9iug4w2+lObpgqfxaCvvsobbDoMo6A==",
+      "requires": {
+        "@aws-sdk/signature-v4": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.13.1.tgz",
+      "integrity": "sha512-tPGjnwkif/ndC1kQ5fv2F2486kUHBoACKKNN1O6CslReDtfFd+Z8kFOkrFtpFufOTRcjc5e4bmaEOG69EGwUUA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.13.1.tgz",
+      "integrity": "sha512-TH2mhvw7V1N3DkqTHmtTwGEWx+y9iP4hST3qzrTYAP72SV6z1ElEZxVvKwOsH97ak1NRgG0DNxgVRIODolQ6Ug==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.13.1.tgz",
+      "integrity": "sha512-+j/9wjDj4Kqf/2Am/qeJbKLYRTcQM1QjULGmQ7uJcvKIg4Orr7XJr8aBhbJgSw2ee7x5WYbun7oBJkNiL1uSCQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.13.1",
+        "@aws-sdk/credential-provider-imds": "3.13.1",
+        "@aws-sdk/credential-provider-web-identity": "3.13.1",
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/shared-ini-file-loader": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.14.0.tgz",
+      "integrity": "sha512-fJUaF5x4YTUmFjzMU/bap8dU+124lUuwz1ugl64VK6qLW78/mGJwZmsmAEc/TbQIm5brv0X7VTgr6z5xUa5YEQ==",
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.13.1",
+        "@aws-sdk/credential-provider-imds": "3.13.1",
+        "@aws-sdk/credential-provider-ini": "3.13.1",
+        "@aws-sdk/credential-provider-process": "3.13.1",
+        "@aws-sdk/credential-provider-sso": "3.14.0",
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/shared-ini-file-loader": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.13.1.tgz",
+      "integrity": "sha512-lvO6hO7at5NHqiCpPDsjvIk8Oj/VK+kgVnFaEufSEw0IL/4avX5llIj2tj3JkqIa6guT7elR6yk70VCwI28ekA==",
+      "requires": {
+        "@aws-sdk/credential-provider-ini": "3.13.1",
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/shared-ini-file-loader": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.14.0.tgz",
+      "integrity": "sha512-PCODdi10TrUUmRgziChUfcCXFvLw1NYdk+sF+JhXwQphlDjK1IKuIYadOqgUEBgNS/y0mX91Gj062CIPzpQ33Q==",
+      "requires": {
+        "@aws-sdk/client-sso": "3.14.0",
+        "@aws-sdk/credential-provider-ini": "3.13.1",
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/shared-ini-file-loader": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.13.1.tgz",
+      "integrity": "sha512-6sJcigee7PUBl4AIva6QfkudpvJ3sZ0MIf5dGCFeElx3j1F5mX15lRt9ZuF31LQ/B5Jc3xBD6rILMH/nQ7Es7A==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.13.1.tgz",
+      "integrity": "sha512-LnucJoP5mRR+uNbXlg8yxVmwQOffWjM1YyBj9q3c2oVYl1mBhdqWL+73kS8iwsXV2YE3wh0Z6seo5B+OpDVJfg==",
+      "requires": {
+        "@aws-crypto/crc32": "^1.0.0",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-hex-encoding": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.13.1.tgz",
+      "integrity": "sha512-lzKDB96LToVLAHVWP2+mhnvuuN2oS/BB9B016wmt7II+DPcqLTdJ4QZ7bTioDGqQ3vLl2xUk8aq3Mrxq8wBDhw==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.13.1",
+        "@aws-sdk/eventstream-serde-universal": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.13.1.tgz",
+      "integrity": "sha512-GtI5czL44t5iNcInwJ4wLScxAwNdf0a7yLYEI4bqr0oEqTZ8hLWAzDtoi4yGsRhvgDRzjxLkRcu/HQWXYGq9GA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.13.1.tgz",
+      "integrity": "sha512-X46ybOppja1Gq4Wv/Laiq3Zs7N7zMl3xM4Iv7vmc1PCbuNEXXHbKbs2w3PH32C7w0yYP795rOJO2LJiBniSFgA==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.13.1",
+        "@aws-sdk/eventstream-serde-universal": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.13.1.tgz",
+      "integrity": "sha512-R3D5uoZxv4QG9yJvo/PQsj+lfpQoxmOSSzBdzbFJfr0FPt3NE2pbOHSfOeMZnLJWRJ6sp58LqhJdVK+GCtfqog==",
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.13.1.tgz",
+      "integrity": "sha512-tG6Vti5gE/IjlpP572m/He55f/F8z/PlwN15cgNiQJrwpilpOW3isApSag+zAsKyek/cNsmCFCb0hJq0F9TumQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/querystring-builder": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-base64-browser": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.13.1.tgz",
+      "integrity": "sha512-RiOwJK8vZb1kWzY6871PDbX4aHRRtvKgE8Jc9YViNBWV2XjHvCizxscXNtdX+MisWoodKxJLvpLvYbhjNhrJMA==",
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.13.1",
+        "@aws-sdk/chunked-blob-reader-native": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.13.1.tgz",
+      "integrity": "sha512-jOxl5z8aIHQ3W5p+lcnJSkcn+qG96PH196P7KBszGlUEAgUUPc+DNoodlP+DK5T4o6tFQU31S+qRIYU/73+pLg==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-buffer-from": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.13.1.tgz",
+      "integrity": "sha512-KHyoTHVM0ei9m+sRrj57uNmwxtO8sBIh/fSQ2e6RtJk7gjBEDkU4dgwPF0FaS9j5VRhTVBPlCMUaHrNGkuAJtQ==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.13.1.tgz",
+      "integrity": "sha512-Cfjcxe09h8jfunNUh5+uygVCOiYo8E1EnuOsqs5+LYUViMnST04/GjIk9499XHBKbh3akwPyBSFxZrOmHUh61Q==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.13.1.tgz",
+      "integrity": "sha512-W1pzDpk5iAaJAZnCHHBwFSU7HW6IbQn71DKe3nnbmTbY56QdKdSZ23r+6uWxtz1xetbEd5JdzWs+AD+Ji1pC7Q==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.13.1.tgz",
+      "integrity": "sha512-+SLzPLoog2y8lz9bw3kitwDhrFf3AIHRtdheUfBMfEPbc1ngHNrp8RFUZApDYUj/80yqj73ux3fgptShtWqBKA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-utf8-browser": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.13.1.tgz",
+      "integrity": "sha512-0G9bGQ951n9KyqwMithX41ucZ0jUkps/mAq6z6AchrUfb1m0NEo6CRMiM6KIl+7ZxLZodiynyq8mRPpRnO0mSA==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.13.1.tgz",
+      "integrity": "sha512-LT6vaOBo2uQGMVsG7QMBGVS8SncZwcuA5WvcUC4npxWnV3JQtpILwA9pceBE/dcVxwB6VyX8b7Tci2e2gioTtg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-arn-parser": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.13.1.tgz",
+      "integrity": "sha512-eAEbPrrbwPHNiO1+INyncbcV5orjXZza3RVkqYinWj6j4tUOxwLqSpbHHhVgRulN+MD+H6YX+x307jaDT4fQfg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.13.1.tgz",
+      "integrity": "sha512-wi8e9UgETIG60BUhlUL0du8Akj1CK0v90QK7hpXZvqJNLzVgAGKvDTnxZVrhxY6SPiNB263/ORq+WemlrtOp6Q==",
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.13.1.tgz",
+      "integrity": "sha512-MOLWAFbEkFWsKE0KE982Z3rbbz5QV2udx8G5jak+3qQz/YpA9770qJqy19DJNLZclWq2EUE1r8lmgVomZD+qfg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.13.1.tgz",
+      "integrity": "sha512-kwa0OLJ+wx2f3Xm1So/ld4ZDq6N7rcXdRZ8qSddCfSRYulxZaew5KdljXxqK9kBglpUE8EKzz1NZjlABc+iEYw==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.13.1.tgz",
+      "integrity": "sha512-Kzu4E6KpoI0NsgxvvgZ1BfOyNnjEX3xPLCuYHjhP4fUicdbXEOllZJ8oNaxhrUjfyqliAVYu03st3mZzipH6ww==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.13.1.tgz",
+      "integrity": "sha512-lgIoYKvoQrRzy06Cfv9hCY5ZmQYoNUlpIKcwpQOqRe7vmtVIanU5m5EjHrTfAKDNbanXvs/vmCB5oDgafzbXFQ==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.13.1.tgz",
+      "integrity": "sha512-AUKQ1Fi2/VUhGaSOSpqkiMY4/ma0ozvQMqCFaKciZA7ZJOq9ptBWr/E/FTd/See1vpiyRTcc9/hbFxW1ClQnqQ==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/service-error-classification": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.13.1.tgz",
+      "integrity": "sha512-l/FcJ3inlfHdPBayY1RGuOb7GDAuMN46NYeM4eAhslSCrxCoVFXfIgLNFTfHRi6Y14KB6iSwMlUpFIXFrWwdWg==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-arn-parser": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.13.1.tgz",
+      "integrity": "sha512-/l2camoPKOHGRzYUELzidtykuGYWrx2ZBmQ1g4JNGjq9ngTtyhGpDxSz6ySOYY/Hln313/+D0Dy6vAvPbOvgRQ==",
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.13.1",
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/signature-v4": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.13.1.tgz",
+      "integrity": "sha512-5C/PPY0SY2NpLVggu5XJAdQw1IqZpcRQBBa3+EpDFoMxUDzgtY2wNOm/IKTX2yYklDnQtyDsP8Z7Cma+Vj2BLA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.13.1.tgz",
+      "integrity": "sha512-0KQPH4EywfnabDjbOSFQ9Nkw7790dBa34v2319bnaurCDRBDcGOB44KJQc8Mlu6ixFRzprnwj4+5qZI7IedWpg==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/signature-v4": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.13.1.tgz",
+      "integrity": "sha512-SYXV0G0uaTPI8t0Qq9aIMMoDJfTr5QdrWc2KAH0y973G7cpB9MPa4d90xQ+4AxLde246FiQS5ExD7N8bXvvA1g==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.13.1.tgz",
+      "integrity": "sha512-ScXJ3w6bp00Em1po1MzcPNJxj8/qct26IBjFEiy2+usetkq3F8zJlRZN053bWMxma3YoyfgQrkuxZiHGaguJbg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.14.0.tgz",
+      "integrity": "sha512-ZmYfKuK/RfEWzX8Xvg9sGU16zAozNu0mxj2hDB6Lu+253D69AbUO4QAAFLJVwIUr4YgZIThss6icOuebPx2zdA==",
+      "requires": {
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.13.1.tgz",
+      "integrity": "sha512-lRfGW7zcJ3Ly6N4fxGc7b+bSa6/LBWwUReVM8c4TI0VrX+1xPBH/DX0APBRxmzBCyjzL+Ls3fo5WLxMLZHNceA==",
+      "requires": {
+        "@aws-sdk/property-provider": "3.13.1",
+        "@aws-sdk/shared-ini-file-loader": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.13.1.tgz",
+      "integrity": "sha512-DksP+IkUM3yqmhcFp4pLd+apYYq1cFQ+o+2FYAaXenGGZ6wiXmBamtF9mt7DIb9tpeSt5kmOh7dTiHQIY24gDg==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.13.1",
+        "@aws-sdk/protocol-http": "3.13.1",
+        "@aws-sdk/querystring-builder": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.13.1.tgz",
+      "integrity": "sha512-uQ8dvpWYxY007rTwqr1COvqD+Z9NAUJjBfP+IYv8j1Dyc9o1Odkkj7Cm3fFFo021hlyCbcYtE3AnppVlAWyaCA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.13.1.tgz",
+      "integrity": "sha512-iTy0TS6KTxNl6dfEj272Q4pxYcEfaljNFhlUBlvAZK04abbhzzlqwtGyGitEv+wSJ6R2e1Gmk6KWUQ2F1CoCng==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.13.1.tgz",
+      "integrity": "sha512-t/AKKzFpS1bwGuHw1nU8IpUmptbaXYWuiZnp6quFvtZjWQV1BKTDG1SEXzY1dowEpv+FNxUp6RdPakIaPInlAA==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-uri-escape": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.13.1.tgz",
+      "integrity": "sha512-FKSEUkZ+csopOVP/LUb8YSu07G/n8tj4sVp3FdX6OPv+HBD0ukfbl4mzyBHJlOgWhzDihxzKL8iHoUuC2FfY3w==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.13.1.tgz",
+      "integrity": "sha512-eVH00KOSTV23RWWY7JMuc2s7jBfiWP/UR82n3knYYtTztcm9pFIIkNhphUnOThWROzNqlW+Dif8ztb85oK5K+Q=="
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.13.1.tgz",
+      "integrity": "sha512-zB+niFj0iIZu2aXmKv2Xhk404Lw6gawTZPjzR4vLuTmn563yhSUSw5hJN+v/O/bR1b3JV4NPubyIQT6CKx1YUA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.13.1.tgz",
+      "integrity": "sha512-j+WCkQCUNhJbeRYW7KTsXd3gxk5CUeZF0LLVOT7HGvxzBhWJkpNGlsFD6ENR5iVpAlmK2yrTLJn7sma7Fgci+Q==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "@aws-sdk/util-hex-encoding": "3.13.1",
+        "@aws-sdk/util-uri-escape": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.13.1.tgz",
+      "integrity": "sha512-DFo9LriBq0b8wQpO6DNnwQ0ISxTLn4tBHNsdXj0vHKKwg6h8IcveUNyLGGDdQejL8FLqOKJfe1NRvkY2UQFsrg==",
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.13.1.tgz",
+      "integrity": "sha512-4eHboRz3I8f0C85Ta1dJ1v1Y9T1zH9xpC4/DufSIfQcD1Imc2U2LM22Qgbz8/PoP4kyhp2nJpQpW0APD91ILfw=="
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.13.1.tgz",
+      "integrity": "sha512-kw9n96GbZ+vuh/KblpcJ1F++hWE7VCQ+cHN5CSxNnN67s/SFk4BLzSeaPup6EUkUI+wIiJMOWW56kIMrcSta5w==",
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.13.1.tgz",
+      "integrity": "sha512-/Y0BEnh1WiVyZQaDMWfqQaRPzEEMrvs0/UTTyknj43dhXoiNDXVyrFUtLw71Oi77WBxk7p/Wbg0m7TVJt3yceQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.13.1.tgz",
+      "integrity": "sha512-bev/PmmRLxTzGkmx88KFhJEL78koIvhYdKFmWtmSJz+trQEk37u6aulWQZF6dpiMGCKYcBfI5h3LsxE75pObTQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-base64-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.13.1.tgz",
+      "integrity": "sha512-z3bh+Luue39gIFOm56FSXOEZJq23J/IUM0Gj28dkdC0hpqdohP2NfcGUBhBlK8CFKBLB5GM1vVKo99T1/OQ/5g==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.13.1.tgz",
+      "integrity": "sha512-qqbBRP1YCuCJ8jCQpP4kbSPrdwJxniccmzsyjkKmaOQoOil69FFNhdwzjrMFhahnsLYD9JUdEsJmHegPbIbUtA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.13.1.tgz",
+      "integrity": "sha512-btSynL8nZmzXPImm/oAaE9aBl1feAZsGv1jR+7+CSM2P5emTEBF4/EuYX34KZTzW7BjSzeDeRK0SHK0IWAB4bw==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.13.1.tgz",
+      "integrity": "sha512-D/LT7a9wwB5Zo4CPWJwP/qdUhs8MYSs+tvyyF2Ox9v8AaUV+w8ukJY9/1/i1cS5bGH7aAjueTiAFSMt8ejVNCg==",
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.13.1.tgz",
+      "integrity": "sha512-NGIqG+L5B6xENgv25BH77F9EeTkN+3tO8sFBeTMjoS7rD3uVP1uLp/RHQENjn/EG/KtgjcNyglngDuS0ZKFOOQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.13.1.tgz",
+      "integrity": "sha512-u1neaf5yO5FdnYF+UHsyDpHzHgMfX87nVDMyOyVvViIIhwDb2+bzzhUbex1rPtTEUfZUtgABV03UZrifGrB15g==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.13.1.tgz",
+      "integrity": "sha512-zejPAiPoS5Zja9nelZUJMdIwiXHKmubgumIV4USB+kgSR4f8BlSj/amM0NdGgZMjyVtuIvdiVHZssM/yK8G1Jg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.13.1.tgz",
+      "integrity": "sha512-j9EL/fWIi5FivsXvjpXjROZEn44LNHY8oUkcFM4C4K8V6dmBK7kwX1svzCAfagwGyrahHkI2F3Isv0zI3FA6DQ==",
+      "requires": {
+        "@aws-sdk/types": "3.13.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.13.1.tgz",
+      "integrity": "sha512-ztECuZn1T0GeRYvmGRlgjs2J/C+BYx2QlImP0Z3xDYeYQnBt8n2dSljutQfF941QaHiB4Ay/NIdfzczZVO7xBA==",
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.13.1.tgz",
+      "integrity": "sha512-+1FmtFOvDOYfoJnC6DEgjpcPKUERZA8VZ7JenY6SsEqVneWzHf4YVE2+KZM0DT9leLzgZBW/DKJWjeKxykaBEg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-utf8-node": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.13.1.tgz",
+      "integrity": "sha512-2SVqcqQQah7cYny6mUmx9UlVIYiaCULnWqOvPkpAKLS3uDFhhFrjvdrQkJXjajR4r7xb73cGn+f2iRXrEqmopw==",
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/util-waiter": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.13.1.tgz",
+      "integrity": "sha512-TpzY3X3QqlD5XaoI4ISjUjz6zjrpsUuxGaiubjbWjXsduW9C9K6jJveTk4FM1KEi4CDPe60J4ypHCE9+G29mfg==",
+      "requires": {
+        "@aws-sdk/abort-controller": "3.13.1",
+        "@aws-sdk/types": "3.13.1",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.14.0.tgz",
+      "integrity": "sha512-TGyodkTPezFTR7vfHiPsynavfeDwbXNTK4r3OYeAt0+tdm3RM6PoUqpkMYLyQgyA+G48uyMunACi/O12H3cwKQ==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
@@ -1207,6 +2063,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1944,6 +2805,11 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
       "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+    },
+    "fast-xml-parser": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
+      "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
     "fastify": {
       "version": "3.14.0",
@@ -3471,6 +4337,11 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4857,6 +5728,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tslib": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.2.0.tgz",
+      "integrity": "sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w=="
+    },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -4988,9 +5864,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-to-istanbul": {
       "version": "7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4337,11 +4337,6 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
-    "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   "author": "Per Liedman <per@liedman.net>",
   "license": "ISC",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.14.0",
     "@turf/meta": "^6.0.2",
     "fastify": "^3.14.0",
     "fastify-cors": "^5.2.0",
-    "lru-cache": "^5.1.1"
+    "lru-cache": "^5.1.1",
+    "node-fetch": "^2.6.1"
   },
   "devDependencies": {
     "jest": "^26.6.3"

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "@turf/meta": "^6.0.2",
     "fastify": "^3.14.0",
     "fastify-cors": "^5.2.0",
-    "lru-cache": "^5.1.1",
-    "node-fetch": "^2.6.1"
+    "lru-cache": "^5.1.1"
   },
   "devDependencies": {
     "jest": "^26.6.3"


### PR DESCRIPTION
Modifies `HGT` to fetch data from S3 instead of the local file system. I tested this approach on an EC2 instance in the same region as the data and it takes approximately 300ms to fetch a tile. 

Many instances of `setImmediate` are also removed because we no longer block with calls to `fs`.

Instead of modifying the tile loader in-place I considered adding S3 as a separate tile loader, but it seemed like it would add more complexity than it is worth