### PR TITLE
[GWEB-1988] Elevation Service Docker base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           region: us-east-1
           repo: gaiagps/elevation-service
           dockerfile: Dockerfile
-          tag: ${CIRCLE_SHA1},${CIRCLE_BRANCH}
+          tag: ${CIRCLE_SHA1}
 
 
 workflows:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:lts
 
 WORKDIR /usr/src/elevation-service
 


### PR DESCRIPTION
The Elevation Service base image is currently Node 14, which was EOL'd [almost a year ago](https://nodejs.org/en/about/previous-releases).

There is no particular reason to pin the base image to a particular Node version; we can use the `node:lts` base image.

Testing:

1. Build Docker image (see repo Readme)
2. Run Docker image (see repo Readme)
3. Exec into Docker image `docker exec -it elevation-service /bin/bash`
4. ~~Run tests~~ tests don't work (were copied from original repo and never updated)

